### PR TITLE
Python 3 compatibility, proxy handling, and limiter selection

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Advect1d is a 1-D advection code, used for advecting solar wind data from the AC
 
 ### Prerequisites
 
-- python 2.7
+- python 2.7 (or greater)
 - spacepy
 - dateutil
 
@@ -18,7 +18,7 @@ To run the advection solver, run
 python advect_imf.py
 ```
 
-This downloads four days worth of ACE data from CDAWeb, and then advects it to the bow shock. It will take several minutes. Output will be written to advected.h5.
+This downloads a short period of DSCOVR solar wind data from CDAWeb, and then advects it to the Earth. It will take several minutes. Output will be written to advected.h5.
 
 To plot the results, run
 

--- a/advect_imf.py
+++ b/advect_imf.py
@@ -58,12 +58,12 @@ def load_acedata(tstart,tend):
 @cache_result(clear=False)
 def load_dscovr(tstart,tend):
     """
-    Fetch ACE data from CDAWeb
+    Fetch DSCOVR data from CDAWeb
 
     tstart: Desired start time
     tend: Desired end time
 
-    Returns: A dictionary of tuples, each containing an array of times and an array of ACE observations for a particular variable
+    Returns: A dictionary of tuples, each containing an array of times and an array of DSCOVR observations for a particular variable
     """
 
     # Download SWEPAM and Mag data from CDAWeb
@@ -137,7 +137,7 @@ def initialize(sw_data,advect_vars=['ux','uy','uz','bx','by','bz','rho','T'],nce
         advect_vars=list(advect_vars)+['ux']
 
     # Start time of simulation is first point for which all variables have valid data
-    t0=np.max([t[0] for var,(t,values) in sw_data.iteritems()])
+    t0=np.max([t[0] for var,(t,values) in sw_data.items()])
 
     for var in sw_data.keys():
 
@@ -149,7 +149,7 @@ def initialize(sw_data,advect_vars=['ux','uy','uz','bx','by','bz','rho','T'],nce
         l1data[var]=t_var,values
 
     # Initialize simulation state vectors
-    state={var:np.ones([ncells])*values[0] for var,[t,values] in sw_data.iteritems() if var in advect_vars}
+    state={var:np.ones([ncells])*values[0] for var,[t,values] in sw_data.items() if var in advect_vars}
     state['x']=x
 
     # Dictionary to hold output variables
@@ -229,7 +229,7 @@ if __name__=='__main__':
     state,outdata,t0,l1data_tnum=initialize(sw_data,output_x=output_x)
 
     # Stop time of simulation is last point for which all variables have valid data
-    tmax=np.min([t[-1] for var,(t,values) in l1data_tnum.iteritems()])
+    tmax=np.min([t[-1] for var,(t,values) in l1data_tnum.items()])
 
     # Step forward in time
     t=0

--- a/advect_imf.py
+++ b/advect_imf.py
@@ -177,7 +177,7 @@ def iterate(state,t,outdata,sw_data,nuMax=0.5,output_x=0,limiter='Minmod'):
     dx=x[1]-x[0]
 
     # Variables to be advected include everything in state except 'x'
-    advect_vars=state.keys()
+    advect_vars = list(state.keys())
     advect_vars.remove('x')
 
     # Put ux on the end of advect_vars since it requires special treatment

--- a/advect_imf.py
+++ b/advect_imf.py
@@ -158,7 +158,7 @@ def initialize(acedata,advect_vars=['ux','uy','uz','bx','by','bz','rho','T'],nce
 
     return state,outdata,t0,l1data
 
-def iterate(state,t,outdata,sw_data,nuMax=0.5,output_x=0):
+def iterate(state,t,outdata,sw_data,nuMax=0.5,output_x=0,limiter='Minmod'):
     """
     Advect L1 observations to Earth
 
@@ -198,10 +198,10 @@ def iterate(state,t,outdata,sw_data,nuMax=0.5,output_x=0):
     # Step variables forward in time
     for var in advect_vars[:-1]:
         a=state[var]
-        step(a,u,dx,dt,'Minmod')
+        step(a,u,dx,dt,limiter)
 
     # ux handled separately since it has a different governing equation
-    step_burgers(u,dx,dt,'Minmod')
+    step_burgers(u,dx,dt,limiter)
     state['ux'][:]=u
 
     # Store output state

--- a/advect_imf.py
+++ b/advect_imf.py
@@ -112,7 +112,7 @@ def load_dscovr(tstart,tend):
     return dscovrdata
         
 
-def initialize(acedata,advect_vars=['ux','uy','uz','bx','by','bz','rho','T'],ncells=1000,l1_x=1.6e6,output_x=0):
+def initialize(sw_data,advect_vars=['ux','uy','uz','bx','by','bz','rho','T'],ncells=1000,l1_x=1.6e6,output_x=0):
     """
     Initialize advection simulation
     

--- a/advect_imf.py
+++ b/advect_imf.py
@@ -8,7 +8,7 @@ from datetime import datetime, timedelta
 import numpy as np
 
 @cache_result(clear=False)
-def load_acedata(tstart,tend):
+def load_acedata(tstart,tend, proxy=None):
     """
     Fetch ACE data from CDAWeb
 
@@ -19,8 +19,8 @@ def load_acedata(tstart,tend):
     """
 
     # Download SWEPAM and Mag data from CDAWeb
-    swepam_data=get_cdf('sp_phys','AC_H0_SWE',tstart,tend,['Np','V_GSM','Tpr','SC_pos_GSM'])
-    mag_data=get_cdf('sp_phys','AC_H0_MFI',tstart,tend,['BGSM'])
+    swepam_data=get_cdf('sp_phys','AC_H0_SWE',tstart,tend,['Np','V_GSM','Tpr','SC_pos_GSM'], proxy=proxy)
+    mag_data=get_cdf('sp_phys','AC_H0_MFI',tstart,tend,['BGSM'], proxy=proxy)
 
     # Dictionary to store all the data from ACE
     acedata={
@@ -56,7 +56,7 @@ def load_acedata(tstart,tend):
         
 
 @cache_result(clear=False)
-def load_dscovr(tstart,tend):
+def load_dscovr(tstart,tend, proxy=None):
     """
     Fetch DSCOVR data from CDAWeb
 
@@ -67,9 +67,9 @@ def load_dscovr(tstart,tend):
     """
 
     # Download SWEPAM and Mag data from CDAWeb
-    plasma_data=get_cdf('sp_phys','DSCOVR_H1_FC',tstart,tend,['Np','V_GSE','THERMAL_TEMP'])
-    mag_data=get_cdf('sp_phys','DSCOVR_H0_MAG',tstart,tend,['B1GSE'])
-    orbit_data=get_cdf('sp_phys','DSCOVR_ORBIT_PRE',tstart,tend,['GSE_POS'])
+    plasma_data=get_cdf('sp_phys','DSCOVR_H1_FC',tstart,tend,['Np','V_GSE','THERMAL_TEMP'], proxy=proxy)
+    mag_data=get_cdf('sp_phys','DSCOVR_H0_MAG',tstart,tend,['B1GSE'], proxy=proxy)
+    orbit_data=get_cdf('sp_phys','DSCOVR_ORBIT_PRE',tstart,tend,['GSE_POS'], proxy=proxy)
 
     # Dictionary to store all the data from DSCOVR
     dscovrdata={
@@ -219,9 +219,9 @@ def iterate(state,t,outdata,sw_data,nuMax=0.5,output_x=0,limiter='Minmod'):
     return dt
 
 if __name__=='__main__':
-
+    proxy = None #('proxy.example.edu:1406', 'https')
     # Fetch solar wind data
-    sw_data=load_dscovr(datetime(2017,9,6,20),datetime(2017,9,7,5))
+    sw_data=load_dscovr(datetime(2017,9,6,20),datetime(2017,9,7,5), proxy=proxy)
 
     output_x=0
 

--- a/cache_decorator.py
+++ b/cache_decorator.py
@@ -1,7 +1,9 @@
 from functools import wraps
 import os
-import cPickle as pkl
-
+try:
+    import cPickle as pkl
+except ImportError: #python 3
+    import _pickle as pkl
 try:
     from functools import lru_cache
 except ImportError:
@@ -20,7 +22,8 @@ def cache_result(clear=False,checkfunc=None,maxsize=10):
         def wrapper(*args,**kwargs):
             import hashlib
             # Pickle the function name and arguments
-            key=pkl.dumps((func.__name__,args,frozenset(kwargs.keys()),frozenset(kwargs.values())))
+            key=pkl.dumps((func.__name__,args,frozenset(list(kwargs.keys())),
+                           frozenset(list(kwargs.values()))))
 
             # Convert the pickled data into a (shorter) unique filename
             cachename=hashlib.md5(key).hexdigest()+'.pkl'
@@ -34,9 +37,9 @@ def cache_result(clear=False,checkfunc=None,maxsize=10):
                 try:
                     result=load_cache(cachename)
                 except:
-                    print 'Error loading result from function '+func.__name__+' with args: '+str(args)
-                    print 'and kwargs: '+str(kwargs)
-                    print 'from file '+cachename
+                    print('Error loading result from function '+func.__name__+' with args: '+str(args))
+                    print('and kwargs: '+str(kwargs))
+                    print('from file '+cachename)
                     raise
             else:
                 result=func(*args,**kwargs)

--- a/cache_decorator.py
+++ b/cache_decorator.py
@@ -15,7 +15,7 @@ def cache_result(clear=False,checkfunc=None,maxsize=10):
     @lru_cache(maxsize=maxsize)
     def load_cache(cachename):
 
-        return pkl.load(open(cachename))
+        return pkl.load(open(cachename, 'rb'))
     
     def decorator(func):
         @wraps(func)
@@ -43,7 +43,7 @@ def cache_result(clear=False,checkfunc=None,maxsize=10):
                     raise
             else:
                 result=func(*args,**kwargs)
-                pkl.dump(result,open(cachename,'w'))
+                pkl.dump(result,open(cachename,'wb'))
             return result
         
         return wrapper

--- a/cdaweb.py
+++ b/cdaweb.py
@@ -138,7 +138,7 @@ def get_file(dataview,dataset,start_date,end_date,variables,format='cdf'):
         variables=(variables,)
 
     url=cdaweb_base_url+'/dataviews/'+dataview+'/datasets/'+dataset+'/data/'+start_date_str+','+end_date_str+'/'+','.join(variables)+'?format='+format
-    print url
+    print(url)
 
     root=fetch_xml(url).getroot()
 

--- a/cdaweb.py
+++ b/cdaweb.py
@@ -6,16 +6,24 @@ import xml.etree.ElementTree as ET
 
 cdaweb_base_url='https://cdaweb.gsfc.nasa.gov/WS/cdasr/1'
 
-def fetch_xml(url, proxy=None):
+def open_url(url, proxy=None):
     """
-    Fetch a URL and parse it as XML using ElementTree
+    Wrap urlopen to use a proxy
 
     proxy - takes a tuple with (proxy_url, proxy_type), e.g. ('proxy.example.edu:1406', 'http')
     """
     req = Request(url)
     if proxy is not None:
-        req.proxy = proxy
+        req.set_proxy(*proxy)
     resp = urlopen(req)
+    return resp
+    
+
+def fetch_xml(url, proxy=None):
+    """
+    Fetch a URL and parse it as XML using ElementTree
+    """
+    resp = open_url(url, proxy=proxy)
     tree = ET.parse(resp)
     return tree
 
@@ -164,7 +172,7 @@ def get_file(dataview,dataset,start_date,end_date,variables,format='cdf', proxy=
         elif error is not None:
             raise ValueError(error)
 
-    data_response=urlopen(file_url)
+    data_response = open_url(file_url, proxy=proxy)
 
     return data_response
 

--- a/cdaweb.py
+++ b/cdaweb.py
@@ -6,11 +6,15 @@ import xml.etree.ElementTree as ET
 
 cdaweb_base_url='https://cdaweb.gsfc.nasa.gov/WS/cdasr/1'
 
-def fetch_xml(url):
+def fetch_xml(url, proxy=None):
     """
     Fetch a URL and parse it as XML using ElementTree
+
+    proxy - takes a tuple with (proxy_url, proxy_type), e.g. ('proxy.example.edu:1406', 'http')
     """
     req = Request(url)
+    if proxy is not None:
+        req.proxy = proxy
     resp = urlopen(req)
     tree = ET.parse(resp)
     return tree
@@ -117,7 +121,7 @@ def datetime_to_cdaweb_url_format(datetime_value):
 
     return '{0:%Y}{0:%m}{0:%d}T{0:%H}{0:%M}{0:%S}Z'.format(datetime_value)
 
-def get_file(dataview,dataset,start_date,end_date,variables,format='cdf'):
+def get_file(dataview,dataset,start_date,end_date,variables,format='cdf', proxy=None):
     """
     Get a data file from CDAWeb
 
@@ -148,7 +152,7 @@ def get_file(dataview,dataset,start_date,end_date,variables,format='cdf'):
     url=cdaweb_base_url+'/dataviews/'+dataview+'/datasets/'+dataset+'/data/'+start_date_str+','+end_date_str+'/'+','.join(variables)+'?format='+format
     print(url)
 
-    root=fetch_xml(url).getroot()
+    root=fetch_xml(url, proxy).getroot()
 
     file_url=root.findtext('cda:FileDescription/cda:Name',namespaces={'cda':'http://cdaweb.gsfc.nasa.gov/schema'})
     

--- a/cdaweb.py
+++ b/cdaweb.py
@@ -1,4 +1,7 @@
-import urllib2
+try:
+    from urllib2 import urlopen, Request
+except ImportError: #python 3
+    from urllib.request import urlopen, Request
 import xml.etree.ElementTree as ET
 
 cdaweb_base_url='https://cdaweb.gsfc.nasa.gov/WS/cdasr/1'
@@ -7,8 +10,9 @@ def fetch_xml(url):
     """
     Fetch a URL and parse it as XML using ElementTree
     """
-    resp=urllib2.urlopen(url)
-    tree=ET.parse(resp)
+    req = Request(url)
+    resp = urlopen(req)
+    tree = ET.parse(resp)
     return tree
 
 def element_to_dict(element):
@@ -79,7 +83,7 @@ def get_datasets(dataview,observatoryGroup=None):
         getdata['observatoryGroup']=observatoryGroup
 
     getstr=''
-    for key,value in getdata.iteritems():
+    for key,value in getdata.items():
         getstr+= key+'='+value
     return xml_to_dict(fetch_xml(cdaweb_base_url+'/dataviews/'+dataview+'/datasets?'+getstr))
 
@@ -134,6 +138,10 @@ def get_file(dataview,dataset,start_date,end_date,variables,format='cdf'):
     start_date_str=datetime_to_cdaweb_url_format(start_date)
     end_date_str=datetime_to_cdaweb_url_format(end_date)
 
+    try:
+        assert basestring
+    except (AssertionError, UnboundLocalError): #Python 3
+        basestring = str
     if isinstance(variables,basestring):
         variables=(variables,)
 
@@ -152,7 +160,7 @@ def get_file(dataview,dataset,start_date,end_date,variables,format='cdf'):
         elif error is not None:
             raise ValueError(error)
 
-    data_response=urllib2.urlopen(file_url)
+    data_response=urlopen(file_url)
 
     return data_response
 

--- a/plot_imf.py
+++ b/plot_imf.py
@@ -11,13 +11,13 @@ from matplotlib import pyplot as plt
 from matplotlib.gridspec import GridSpec
 
 @cache_result()
-def load_omni(dtstart,dtend):
-    return get_cdf('sp_phys','OMNI_HRO_1MIN',dtstart,dtend,['BX_GSE','BY_GSM','BZ_GSM','Vx','Vy','Vz','T','proton_density'])
+def load_omni(dtstart,dtend, proxy=None):
+    return get_cdf('sp_phys','OMNI_HRO_1MIN',dtstart,dtend,['BX_GSE','BY_GSM','BZ_GSM','Vx','Vy','Vz','T','proton_density'], proxy=proxy)
 
 # Fetch OMNI data
-omnidata=load_omni(datetime(2017,9,6,20),datetime(2017,9,7,5))
+omnidata=load_omni(datetime(2017,9,6,20),datetime(2017,9,7,5), proxy=proxy)
 
-l1data=load_dscovr(datetime(2017,9,6,20),datetime(2017,9,7,5))
+l1data=load_dscovr(datetime(2017,9,6,20),datetime(2017,9,7,5), proxy=proxy)
 
 # Read advect1d output
 advect1d_data=dm.fromHDF5('advected.h5')


### PR DESCRIPTION
Changes are 3 flavours:
1. Compatibility with Python 3. Everything should still be Python 2 compatible, but Python 2 is EOL very soon.
    - print statements -> functions
    - dict iteritems -> items
    - binary mode specified for read/write in cache decorators
    - various Python 3 "view" items (like dict.keys()) wrapped in lists
2. The various file fetching routines didn't work behind a proxy server. Support for a proxy now added.
3. The limiter was a keyword argument in a few of the lower level routines, but was hardcoded to 'Minmod' in the `iterate` function. This is now also a keyword argument for `iterate`, with the default set to 'Minmod'

Additional changes:
 - `README.md` updated to reflect recent changes
 - Fixed the variable name for the input data in `initialize` (was missed in change from `acedata` to `sw_data`)
 - Updated the `load_dscovr` docstring