### PR TITLE
Add gap-filling alogrithm

### DIFF
--- a/advect_imf.py
+++ b/advect_imf.py
@@ -6,7 +6,7 @@ from cache_decorator import cache_result
 
 from datetime import datetime, timedelta
 import numpy as np
-
+from spacepy import pybats
 
 @cache_result(clear=False)
 def load_acedata(tstart,tend, noise = True, proxy=None):

--- a/advect_imf.py
+++ b/advect_imf.py
@@ -242,8 +242,28 @@ if __name__=='__main__':
         t+=dt
         i+=1
 
-    # Write output to disk
-    import spacepy.datamodel as dm
+    # Convert timesteps to datetimes
+    outdata['time'] = [starttime + timedelta(seconds = n)
+                        for n in outdata['time']] 
+    
+    # Set up pram and temp keys
+    outdata['pram_1'] = np.multiply(outdata['ux'], outdata['ux'])
+    outdata['pram_2'] = np.multiply(outdata['pram_1'], outdata['rho'])
+    outdata['pram'] = 1.67621e-6*outdata['pram_2']
+    
+    outdata['temp'] = outdata['T']
+    
+    # Set up dictionary
+    imf = pybats.ImfInput(load=False)
+    for key in imf.keys():
+        imf[key] = dm.dmarray(outdata[key])   
+        
+
+    # Write the IMF data to .dat file
+    imf.write('IMF_data.dat')
+    
+    
+    # Write the IMF data to .h5 file
     outhdf=dm.SpaceData()
     for key in outdata.keys():
         outhdf[key]=dm.dmarray(outdata[key])

--- a/advect_imf.py
+++ b/advect_imf.py
@@ -1,20 +1,22 @@
 from matplotlib import pyplot as plt
 from spacepy import datamodel as dm
 from cdaweb import get_cdf
-
+from missing import fill_gaps
 from cache_decorator import cache_result
 
 from datetime import datetime, timedelta
 import numpy as np
 
+
 @cache_result(clear=False)
-def load_acedata(tstart,tend, proxy=None):
+def load_acedata(tstart,tend, noise = True, proxy=None):
     """
     Fetch ACE data from CDAWeb
 
     tstart: Desired start time
     tend: Desired end time
-
+    noise: Adds noise to fill_gaps function
+    
     Returns: A dictionary of tuples, each containing an array of times and an array of ACE observations for a particular variable
     """
 
@@ -33,7 +35,7 @@ def load_acedata(tstart,tend, proxy=None):
         for dataset,local_name,cdaweb_name in [(mag_data,'b','BGSM'),
                                  (swepam_data,'u','V_GSM'),
                                  (swepam_data,'','SC_pos_GSM')]:
-            t,values=dataset['Epoch'],dataset[cdaweb_name][:,i]
+            t,values=dataset['Epoch'],fill_gaps(dataset[cdaweb_name][:,i], noise = noise)
             
             # Grab the appropriate component from
             # VALIDMIN and VALIDMAX attributes
@@ -56,12 +58,13 @@ def load_acedata(tstart,tend, proxy=None):
         
 
 @cache_result(clear=False)
-def load_dscovr(tstart,tend, proxy=None):
+def load_dscovr(tstart,tend, noise = True, proxy=None):
     """
     Fetch DSCOVR data from CDAWeb
 
     tstart: Desired start time
     tend: Desired end time
+    noise: Adds noise to fill_gaps function
 
     Returns: A dictionary of tuples, each containing an array of times and an array of DSCOVR observations for a particular variable
     """
@@ -83,7 +86,7 @@ def load_dscovr(tstart,tend, proxy=None):
                 (mag_data,'b','B1GSE','Epoch1'),
                 (plasma_data,'u','V_GSE','Epoch'),
                 (orbit_data,'','GSE_POS','Epoch')]:
-            t,values=dataset[cdaweb_time_var],dataset[cdaweb_name][:,i]
+            t,values=dataset[cdaweb_time_var],fill_gaps(dataset[cdaweb_name][:,i], noise = noise)
 
             for attr in ('VALIDMIN','VALIDMAX'):
 

--- a/missing.py
+++ b/missing.py
@@ -1,0 +1,66 @@
+import copy
+import random
+import numpy as np
+from scipy.ndimage.filters import gaussian_filter
+
+def fill_gaps(data, fillval=9999999, sigma=5, winsor=0.05, noise=False, constrain=False):
+    '''Fill gaps in input data series, using interpolation plus noise
+
+    The noise approach is based on Owens et al. (Space Weather, 2014).
+
+    data - input numpy ndarray-like
+    fillval - value marking fill in the time series
+    sigma - width of gaussian filter for finding fluctuation CDF
+    winsor - winsorization threshold, values above p=1-winsor and below p=winsor are capped
+    noise - Boolean, if True add noise to interpolated region, if False use linear interp only
+    constrain - Boolean, if True 
+    '''
+    # identify sequences of fill in data series
+    gaps = np.zeros((len(data),2),dtype=int)
+    k = 0
+    for i in range(1,len(data)-1):
+        # Single space gap/fillval
+        if data[i] == fillval and data[i+1] != fillval and data[i-1] != fillval:
+            gaps[k][0] = i
+            gaps[k][1] = i
+            k += 1
+        # Start of multispace gap/fillval
+        elif data[i] == fillval and data[i-1] != fillval:
+            gaps[k][0] = i
+        # End of multispace gap/fillval
+        elif data[i] == fillval and data[i+1] != fillval:
+            gaps[k][1] = i
+            k += 1
+    if k == 0: continue
+    gaps = gaps[:k]
+
+    # fill gaps with linear interpolation
+    for gap in gaps:
+        a = data[gap[0]-1]
+        b = data[gap[1]+1]
+        dx = (b-a)/(gap[1]-gap[0]+2)
+        for i in range(gap[1]-gap[0]+1):
+            data[gap[0]+i] = a + dx*(i+1)
+
+    if noise:
+        # generate CDF from delta var
+        series = data.copy()
+        smooth = gaussian_filter(series, sigma)
+        dx = series-smooth
+        dx.sort()
+        p = np.linspace(0,1,len(dx))
+        # "Winsorize" - all delta-Var above/below threshold at capped at threshold
+        dx[:p.searchsorted(0.+winsor)] = dx[p.searchsorted(0.+winsor)+1]
+        dx[p.searchsorted(1.-winsor):] = dx[p.searchsorted(1.-winsor)-1]
+
+        # draw fluctuations from CDF and apply to linearly filled gaps
+        for gap in gaps:
+            for i in range(gap[1]-gap[0]+1):
+                data[gap[0]+i] += dx[p.searchsorted(random.random())]
+
+        # cap variable if it should be strictly positive (e.g. number density)
+        # use lowest measured value as floor
+        if constrain and series.min() > 0.0:
+            data[data < series.min()] = series.min()
+
+    return data

--- a/missing.py
+++ b/missing.py
@@ -32,8 +32,11 @@ def fill_gaps(data, fillval=9999999, sigma=5, winsor=0.05, noise=False, constrai
         elif (tb.feq(data[i],fillval)) and (~tb.feq(data[i+1],fillval)):
             gaps[k][1] = i
             k += 1
-            if k == 0: continue
     gaps = gaps[:k]
+
+    #if no gaps detected
+    if k==0:
+        return data
 
     # fill gaps with linear interpolation
     for gap in gaps:

--- a/missing.py
+++ b/missing.py
@@ -1,6 +1,7 @@
 import copy
 import random
 import numpy as np
+import spacepy.toolbox as tb
 from scipy.ndimage.filters import gaussian_filter
 
 def fill_gaps(data, fillval=9999999, sigma=5, winsor=0.05, noise=False, constrain=False):
@@ -20,18 +21,18 @@ def fill_gaps(data, fillval=9999999, sigma=5, winsor=0.05, noise=False, constrai
     k = 0
     for i in range(1,len(data)-1):
         # Single space gap/fillval
-        if data[i] == fillval and data[i+1] != fillval and data[i-1] != fillval:
+        if (tb.feq(data[i],fillval)) and (~tb.feq(data[i+1],fillval)) and (~tb.feq(data[i-1],fillval)):
             gaps[k][0] = i
             gaps[k][1] = i
             k += 1
         # Start of multispace gap/fillval
-        elif data[i] == fillval and data[i-1] != fillval:
+        elif (tb.feq(data[i],fillval)) and (~tb.feq(data[i-1],fillval)):
             gaps[k][0] = i
         # End of multispace gap/fillval
-        elif data[i] == fillval and data[i+1] != fillval:
+        elif (tb.feq(data[i],fillval)) and (~tb.feq(data[i+1],fillval)):
             gaps[k][1] = i
             k += 1
-    if k == 0: continue
+            if k == 0: continue
     gaps = gaps[:k]
 
     # fill gaps with linear interpolation


### PR DESCRIPTION
Original behaviour has implicit linear interpolation across gaps, as the code interpolates linearly to the exact time required by the stepper. So larger gaps are filled linearly.

This PR adds code that fills gaps explicitly prior to the advection simulation. It will perform either:
1. Linear interpolation (giving the same behaviour as before), or
2. A noisy gap-filling.
(The method is selectable)

The latter is an algorithm designed by M. Engel and S. Morley at LANL, based on work by M. Owens at University of Reading. In essence, it uses the CDF of steps between adjacent times to build a series that (first-order) has the same distribution of jumps. I.e., it fills linearly, but with _noise_ drawn from observation on top of the linear fill. For larger gaps, this is intended to preserve the higher-frequency components that may be important when driving geospace models.