### PR TITLE
Expanded option parsing, added config file handling

### DIFF
--- a/advect_imf.py
+++ b/advect_imf.py
@@ -264,7 +264,7 @@ def parse_args(starttime=None, endtime=None):
                              'of Earth. Defaults to 203872 (32 Earth radii).')
     parser.add_argument('--ncells',
                         default=1000,
-                        dest=ncells,
+                        dest='ncells',
                         help='Number of cells, between L1 and Earth, used by advection ' +
                              'code. Defaults to 1000.')
     parser.add_argument('--source', default='DSCOVR',

--- a/advect_imf.py
+++ b/advect_imf.py
@@ -259,11 +259,13 @@ def parse_args(starttime=None, endtime=None):
                              'universal time in YYYY-MM-DDTHH:MM:SS')
     parser.add_argument('--output-x',
                         default=203872,
+                        type=int,
                         dest='output_x',
                         help='Location used for output, given in km upstream ' +
                              'of Earth. Defaults to 203872 (32 Earth radii).')
     parser.add_argument('--ncells',
                         default=1000,
+                        type=int,
                         dest='ncells',
                         help='Number of cells, between L1 and Earth, used by advection ' +
                              'code. Defaults to 1000.')

--- a/advect_imf.py
+++ b/advect_imf.py
@@ -1,76 +1,76 @@
-#stdlib
+# stdlib
 import os
 import sys
 from datetime import datetime, timedelta
 try:
-    #Python 3
+    # Python 3
     from configparser import ConfigParser
 except ImportError:
     from ConfigParser import ConfigParser
 
-#local
+# local
 from cdaweb import get_cdf
 from missing import fill_gaps
 from cache_decorator import cache_result
 
-#extras
+# extras
 import numpy as np
-from matplotlib import pyplot as plt
 from spacepy import datamodel as dm
 from spacepy import pybats
 
 
 @cache_result(clear=False)
-def load_acedata(tstart,tend, noise = True, proxy=None):
+def load_acedata(tstart, tend, noise=True, proxy=None):
     """
     Fetch ACE data from CDAWeb
 
     tstart: Desired start time
     tend: Desired end time
     noise: Adds noise to fill_gaps function
-    
-    Returns: A dictionary of tuples, each containing an array of times and an array of ACE observations for a particular variable
+
+    Returns: A dictionary of tuples, each containing an array of times
+             and an array of ACE observations for a particular variable
     """
 
     # Download SWEPAM and Mag data from CDAWeb
-    swepam_data=get_cdf('sp_phys','AC_H0_SWE',tstart,tend,['Np','V_GSM','Tpr','SC_pos_GSM'], proxy=proxy)
-    mag_data=get_cdf('sp_phys','AC_H0_MFI',tstart,tend,['BGSM'], proxy=proxy)
+    swepam_data = get_cdf('sp_phys', 'AC_H0_SWE', tstart, tend,
+                          ['Np', 'V_GSM', 'Tpr', 'SC_pos_GSM'], proxy=proxy)
+    mag_data = get_cdf('sp_phys', 'AC_H0_MFI', tstart, tend,
+                       ['BGSM'], proxy=proxy)
 
     # Dictionary to store all the data from ACE
-    acedata={
-        'T':(swepam_data['Epoch'],swepam_data['Tpr']),
-        'rho':(swepam_data['Epoch'],swepam_data['Np']),
-    }
+    acedata = {'T': (swepam_data['Epoch'], swepam_data['Tpr']),
+               'rho': (swepam_data['Epoch'], swepam_data['Np']),
+               }
 
     # Store all the vector data in the array
-    for i,coord in enumerate('xyz'):
-        for dataset,local_name,cdaweb_name in [(mag_data,'b','BGSM'),
-                                 (swepam_data,'u','V_GSM'),
-                                 (swepam_data,'','SC_pos_GSM')]:
-            t,values=dataset['Epoch'],fill_gaps(dataset[cdaweb_name][:,i], noise = noise)
-            
+    for i, coord in enumerate('xyz'):
+        for dataset, local_name, cdaweb_name in [(mag_data, 'b', 'BGSM'),
+                                                 (swepam_data, 'u', 'V_GSM'),
+                                                 (swepam_data, '', 'SC_pos_GSM')]:
+            t, values = dataset['Epoch'], fill_gaps(dataset[cdaweb_name][:, i], noise=noise)
+
             # Grab the appropriate component from
             # VALIDMIN and VALIDMAX attributes
-            values.attrs['VALIDMIN']=values.attrs['VALIDMIN'][i]
-            values.attrs['VALIDMAX']=values.attrs['VALIDMAX'][i]
+            values.attrs['VALIDMIN'] = values.attrs['VALIDMIN'][i]
+            values.attrs['VALIDMAX'] = values.attrs['VALIDMAX'][i]
 
             # Store in acedata dict
-            acedata[local_name+coord]=t,values
+            acedata[local_name+coord] = t, values
 
     for var in acedata.keys():
-        
         # Restrict to only valid data
-        t_var,varIn=acedata[var]
-        goodpoints=(varIn<varIn.attrs['VALIDMAX']) & (varIn>varIn.attrs['VALIDMIN'])
-        t_var,varIn=t_var[goodpoints],varIn[goodpoints]
+        t_var, varIn = acedata[var]
+        goodpoints = (varIn < varIn.attrs['VALIDMAX']) & (varIn > varIn.attrs['VALIDMIN'])
+        t_var, varIn = t_var[goodpoints], varIn[goodpoints]
 
-        acedata[var]=(t_var,varIn)
-        
+        acedata[var] = (t_var, varIn)
+
     return acedata
-        
+
 
 @cache_result(clear=False)
-def load_dscovr(tstart,tend, noise = True, proxy=None):
+def load_dscovr(tstart, tend, noise=True, proxy=None):
     """
     Fetch DSCOVR data from CDAWeb
 
@@ -78,29 +78,30 @@ def load_dscovr(tstart,tend, noise = True, proxy=None):
     tend: Desired end time
     noise: Adds noise to fill_gaps function
 
-    Returns: A dictionary of tuples, each containing an array of times and an array of DSCOVR observations for a particular variable
+    Returns: A dictionary of tuples, each containing an array of times and an
+             array of DSCOVR observations for a particular variable
     """
 
     # Download SWEPAM and Mag data from CDAWeb
-    plasma_data=get_cdf('sp_phys','DSCOVR_H1_FC',tstart,tend,['Np','V_GSE','THERMAL_TEMP'], proxy=proxy)
-    mag_data=get_cdf('sp_phys','DSCOVR_H0_MAG',tstart,tend,['B1GSE'], proxy=proxy)
-    orbit_data=get_cdf('sp_phys','DSCOVR_ORBIT_PRE',tstart,tend,['GSE_POS'], proxy=proxy)
+    plasma_data = get_cdf('sp_phys', 'DSCOVR_H1_FC', tstart, tend,
+                          ['Np', 'V_GSE', 'THERMAL_TEMP'], proxy=proxy)
+    mag_data = get_cdf('sp_phys', 'DSCOVR_H0_MAG', tstart, tend, ['B1GSE'], proxy=proxy)
+    orbit_data = get_cdf('sp_phys', 'DSCOVR_ORBIT_PRE', tstart, tend, ['GSE_POS'], proxy=proxy)
 
     # Dictionary to store all the data from DSCOVR
-    dscovrdata={
-        'T':(plasma_data['Epoch'],plasma_data['THERMAL_TEMP']),
-        'rho':(plasma_data['Epoch'],plasma_data['Np']),
-    }
+    dscovrdata = {'T': (plasma_data['Epoch'], plasma_data['THERMAL_TEMP']),
+                  'rho': (plasma_data['Epoch'], plasma_data['Np']),
+                  }
 
     # Store all the vector data in the array
-    for i,coord in enumerate('xyz'):
-        for dataset,local_name,cdaweb_name,cdaweb_time_var in [
-                (mag_data,'b','B1GSE','Epoch1'),
-                (plasma_data,'u','V_GSE','Epoch'),
-                (orbit_data,'','GSE_POS','Epoch')]:
-            t,values=dataset[cdaweb_time_var],fill_gaps(dataset[cdaweb_name][:,i], noise = noise)
+    for i, coord in enumerate('xyz'):
+        for dataset, local_name, cdaweb_name, cdaweb_time_var in [
+                (mag_data, 'b', 'B1GSE', 'Epoch1'),
+                (plasma_data, 'u', 'V_GSE', 'Epoch'),
+                (orbit_data, '', 'GSE_POS', 'Epoch')]:
+            t, values = dataset[cdaweb_time_var], fill_gaps(dataset[cdaweb_name][:, i], noise=noise)
 
-            for attr in ('VALIDMIN','VALIDMAX'):
+            for attr in ('VALIDMIN', 'VALIDMAX'):
 
                 try:
                     len(values.attrs[attr])
@@ -110,86 +111,91 @@ def load_dscovr(tstart,tend, noise = True, proxy=None):
                 else:
                     # Grab the appropriate component from
                     # VALIDMIN and VALIDMAX attributes
-                    values.attrs[attr]=values.attrs[attr][0]
+                    values.attrs[attr] = values.attrs[attr][0]
 
             # Store in data dict
-            dscovrdata[local_name+coord]=t,values
+            dscovrdata[local_name+coord] = t, values
 
     for var in dscovrdata.keys():
-        
         # Restrict to only valid data
-        t_var,varIn=dscovrdata[var]
-        goodpoints= (varIn>varIn.attrs['VALIDMIN'])
-        t_var,varIn=t_var[goodpoints],varIn[goodpoints]
+        t_var, varIn = dscovrdata[var]
+        goodpoints = (varIn > varIn.attrs['VALIDMIN'])
+        t_var, varIn = t_var[goodpoints], varIn[goodpoints]
 
-        dscovrdata[var]=(t_var,varIn)
-        
+        dscovrdata[var] = (t_var, varIn)
+
     return dscovrdata
-        
 
-def initialize(sw_data,advect_vars=['ux','uy','uz','bx','by','bz','rho','T'],ncells=1000,l1_x=1.6e6,output_x=0):
+
+def initialize(sw_data, advect_vars=['ux', 'uy', 'uz', 'bx', 'by', 'bz', 'rho', 'T'],
+               ncells=1000, l1_x=1.6e6, output_x=0):
     """
     Initialize advection simulation
-    
-    sw_data: Dictionary of L1 solar wind data, structured in the form returned from load_acedata or load_dscovr
+
+    sw_data: Dictionary of L1 solar wind data, structured in the form returned from
+             load_acedata or load_dscovr
     advect_vars: Keys in the sw_data dictionary for variables that should be advected
     ncells: Number of cells in the computational grid
     l1_x: Maximum coordinate (in GSM/GSE x, units of km) of the upstream solar wind data
     output_x: Minimum coordinate (in GSM/GSE x, km) where output will be needed
     """
 
-    l1data={}
+    l1data = {}
 
-    xextent=l1_x-output_x
-    max_x=l1_x+xextent*(2./ncells)
-    min_x=output_x-xextent*(2./ncells)
+    xextent = l1_x-output_x
+    max_x = l1_x+xextent*(2./ncells)
+    min_x = output_x-xextent*(2./ncells)
 
     # Make the grid
-    x=np.linspace(min_x,max_x,ncells)
+    x = np.linspace(min_x, max_x, ncells)
 
     # ux must be advected regardless
     if 'ux' not in advect_vars:
-        advect_vars=list(advect_vars)+['ux']
+        advect_vars = list(advect_vars)+['ux']
 
     # Start time of simulation is first point for which all variables have valid data
-    t0=np.max([t[0] for var,(t,values) in sw_data.items()])
+    t0 = np.max([t[0] for var, (t, values) in sw_data.items()])
 
     for var in sw_data.keys():
 
-        t_var,values=sw_data[var]
+        t_var, values = sw_data[var]
 
         # Subtract epoch time from time arrays and convert them to seconds
-        t_var=np.array([(t-t0).total_seconds() for t in t_var])
+        t_var = np.array([(t-t0).total_seconds() for t in t_var])
 
-        l1data[var]=t_var,values
+        l1data[var] = t_var, values
 
     # Initialize simulation state vectors
-    state={var:np.ones([ncells])*values[0] for var,[t,values] in sw_data.items() if var in advect_vars}
-    state['x']=x
+    state = {var: np.ones([ncells])*values[0] for var, [t, values] in sw_data.items()
+             if var in advect_vars}
+    state['x'] = x
 
     # Dictionary to hold output variables
-    outdata={var:[] for var in advect_vars}
-    outdata['time']=[]
+    outdata = {var: [] for var in advect_vars}
+    outdata['time'] = []
 
-    return state,outdata,t0,l1data
+    return state, outdata, t0, l1data
 
-def iterate(state,t,outdata,sw_data,nuMax=0.5,output_x=0,limiter='Minmod'):
+
+def iterate(state, t, outdata, sw_data, nuMax=0.5, output_x=0, limiter='Minmod'):
     """
     Advect L1 observations to Earth
 
     state: dictionary of state variables, as generated by initialize()
     t: Current time associated with state
     outdata: Dictionary to store the output data
-    sw_data: Dictionary of L1 solar wind data, structured in the form returned from load_acedata or load_dscovr
+    sw_data: Dictionary of L1 solar wind data, structured in the form returned from
+             load_acedata or load_dscovr
     nuMax: Maximum allowed CFL
-    output_x: x coordinate (in the GSM/GSE coordinate system with units of km) where output values should be provided
+    output_x: x coordinate (in the GSM/GSE coordinate system with units of km) where
+              output values should be provided
     """
 
     from advect1d import step, step_burgers, updateboundary
 
-    u=state['ux']
-    x=state['x']
-    dx=x[1]-x[0]
+    u = state['ux']
+    x = state['x']
+    dx = x[1]-x[0]
 
     # Variables to be advected include everything in state except 'x'
     advect_vars = list(state.keys())
@@ -201,169 +207,167 @@ def iterate(state,t,outdata,sw_data,nuMax=0.5,output_x=0,limiter='Minmod'):
 
     # Update boundary conditions with values at new time step
     for var in advect_vars:
-        
-        a=state[var]
-        var_t,values=sw_data[var]
-        x_sat_t,x_sat=sw_data['x']
-        updateboundary(a,t,x,x_sat,x_sat_t,values,var_t)
-        
+        a = state[var]
+        var_t, values = sw_data[var]
+        x_sat_t, x_sat = sw_data['x']
+        updateboundary(a, t, x, x_sat, x_sat_t, values, var_t)
+
     # Find the time step
-    dt=nuMax/np.abs(np.min(u))*dx
-        
+    dt = nuMax/np.abs(np.min(u))*dx
+
     # Step variables forward in time
     for var in advect_vars[:-1]:
-        a=state[var]
-        step(a,u,dx,dt,limiter)
+        a = state[var]
+        step(a, u, dx, dt, limiter)
 
     # ux handled separately since it has a different governing equation
-    step_burgers(u,dx,dt,limiter)
-    state['ux'][:]=u
+    step_burgers(u, dx, dt, limiter)
+    state['ux'][:] = u
 
     # Store output state
     for var in advect_vars:
         from scipy.interpolate import interp1d
 
         # Interpolate state variable to point where output is requested
-        outdata[var].append(
-            interp1d(x,state[var])(output_x)
-        )
+        outdata[var].append(interp1d(x, state[var])(output_x))
 
     # Append time to output state
     outdata['time'].append(t+dt)
 
     return dt
 
-def parse_args(starttime=None,endtime=None):
+
+def parse_args(starttime=None, endtime=None):
     from argparse import ArgumentParser
 
-    parser=ArgumentParser()
+    parser = ArgumentParser()
 
-    starttime=starttime or datetime(2017,9,6,20)
-    endtime=endtime or datetime(2017,9,7,5)
+    starttime = starttime or datetime(2017, 9, 6, 20)
+    endtime = endtime or datetime(2017, 9, 7, 5)
 
-    parser.add_argument('--start-time', 
-                        type=lambda s: datetime.strptime(s,'%Y-%m-%dT%H:%M:%S'),
+    parser.add_argument('--start-time',
+                        type=lambda s: datetime.strptime(s, '%Y-%m-%dT%H:%M:%S'),
                         default=starttime,
                         dest='start_time',
-                        help='Start time of solar wind observations, ' + \
+                        help='Start time of solar wind observations, ' +
                              'universal time in YYYY-MM-DDTHH:MM:SS')
     parser.add_argument('--end-time',
-                        type=lambda s: datetime.strptime(s,'%Y-%m-%dT%H:%M:%S'),
+                        type=lambda s: datetime.strptime(s, '%Y-%m-%dT%H:%M:%S'),
                         default=endtime,
                         dest='end_time',
-                        help='Start time of solar wind observations, ' + \
+                        help='Start time of solar wind observations, ' +
                              'universal time in YYYY-MM-DDTHH:MM:SS')
     parser.add_argument('--output-x',
                         default=203872,
                         dest='output_x',
-                        help='Location used for output, given in km upstream ' + \
+                        help='Location used for output, given in km upstream ' +
                              'of Earth. Defaults to 203872 (32 Earth radii).')
     parser.add_argument('--source', default='DSCOVR',
                         help='Solar wind data source ("ACE" or "DSCOVR")')
     parser.add_argument('--proxy', help='Proxy server URL')
     parser.add_argument('--disable-noise', action='store_true',
-                        help='By default, data gaps in the upstream solar ' + \
-                             'wind data will be filled with a noisy ' + \
-                             'interpolation algorithm developed by M. Engel ' + \
-                             'and S. Morley. With this argument, the noisy ' + \
-                             'interpolation is disabled and a linear ' + \
+                        help='By default, data gaps in the upstream solar ' +
+                             'wind data will be filled with a noisy ' +
+                             'interpolation algorithm developed by M. Engel ' +
+                             'and S. Morley. With this argument, the noisy ' +
+                             'interpolation is disabled and a linear ' +
                              'interpolation used instead')
     parser.add_argument('-c', '--config', dest='configFile', default=None,
                         help='Name of configuration file to use (optional)')
-    args=parser.parse_args()
+    args = parser.parse_args()
 
-    #handle config file if present
-    #variables set in the config file take precedence
+    # handle config file if present
+    # variables set in the config file take precedence
     if args.configFile is not None:
         config = ConfigParser()
         with open(args.configFile, 'r') as fh:
-            if sys.version_info.major>=3:
+            if sys.version_info.major >= 3:
                 config.read_file(fh)
             else:
-                config.readfp(fh) #legacy Python 2 support
+                config.readfp(fh)  # legacy Python 2 support
         for ckey in config.options('Settings'):
             try:
                 args.__dict__[ckey] = config.get('Settings', ckey)
             except:
                 pass
 
-    proxy=args.proxy or os.environ.get('http_proxy')
+    proxy = args.proxy or os.environ.get('http_proxy')
 
     if proxy:
         # Convert proxy URL into a tuple to be passed to
         # urllib2.Request.set_proxy
         import re
-        m=re.match('((?P<scheme>[a-z]+)://)?(?P<host>\w+)/?',proxy)
-        scheme=m.group('scheme') or 'http'
-        host=m.group('host')
-        args.proxy=(host,scheme)
+        m = re.match('((?P<scheme>[a-z]+)://)?(?P<host>\w+)/?', proxy)
+        scheme = m.group('scheme') or 'http'
+        host = m.group('host')
+        args.proxy = (host, scheme)
 
     return args
 
-def fetch_solarwind(starttime,endtime,source='DSCOVR',proxy=None):
-    if source=='DSCOVR':
-        sw_data=load_dscovr(starttime,endtime, proxy=proxy)
-    elif source=='ACE':
-        sw_data=load_acedata(starttime,endtime, proxy=proxy)
+
+def fetch_solarwind(starttime, endtime, source='DSCOVR', proxy=None):
+    if source == 'DSCOVR':
+        sw_data = load_dscovr(starttime, endtime, proxy=proxy)
+    elif source == 'ACE':
+        sw_data = load_acedata(starttime, endtime, proxy=proxy)
     else:
         raise ValueError('Invalid source ''{}'''.format(source))
 
     return sw_data
 
-if __name__=='__main__':
 
-    args=parse_args()
+if __name__ == '__main__':
 
-    noise=not args.disable_noise
+    args = parse_args()
 
-    starttime=args.start_time
-    endtime=args.end_time
-    source=args.source
-    proxy=args.proxy
+    noise = not args.disable_noise
+
+    starttime = args.start_time
+    endtime = args.end_time
+    source = args.source
+    proxy = args.proxy
 
     # Fetch solar wind data
-    sw_data=fetch_solarwind(starttime,endtime,source,proxy)
+    sw_data = fetch_solarwind(starttime, endtime, source, proxy)
 
-    output_x=203872
+    output_x = 203872
 
     # Initialize the simulation state
-    state,outdata,t0,l1data_tnum=initialize(sw_data,output_x=output_x)
+    state, outdata, t0, l1data_tnum = initialize(sw_data, output_x=output_x)
 
     # Stop time of simulation is last point for which all variables have valid data
-    tmax=np.min([t[-1] for var,(t,values) in l1data_tnum.items()])
+    tmax = np.min([t[-1] for var, (t, values) in l1data_tnum.items()])
 
     # Step forward in time
-    t=0
-    i=0
-    while t<tmax:
-        dt=iterate(state,t,outdata,l1data_tnum,output_x=output_x)
-        t+=dt
-        i+=1
+    t = 0
+    i = 0
+    while t < tmax:
+        dt = iterate(state, t, outdata, l1data_tnum, output_x=output_x)
+        t += dt
+        i += 1
 
     # Convert timesteps to datetimes
-    outdata['time'] = [starttime + timedelta(seconds = n)
-                        for n in outdata['time']] 
-    
+    outdata['time'] = [starttime + timedelta(seconds=n)
+                       for n in outdata['time']]
+
     # Set up pram and temp keys
     outdata['pram_1'] = np.multiply(outdata['ux'], outdata['ux'])
     outdata['pram_2'] = np.multiply(outdata['pram_1'], outdata['rho'])
     outdata['pram'] = 1.67621e-6*outdata['pram_2']
-    
+
     outdata['temp'] = outdata['T']
-    
+
     # Set up dictionary
     imf = pybats.ImfInput(load=False)
     for key in imf.keys():
-        imf[key] = dm.dmarray(outdata[key])   
-        
+        imf[key] = dm.dmarray(outdata[key])
 
     # Write the IMF data to .dat file
     imf.write('IMF_data.dat')
-    
-    
+
     # Write the IMF data to .h5 file
-    outhdf=dm.SpaceData()
+    outhdf = dm.SpaceData()
     for key in outdata.keys():
-        outhdf[key]=dm.dmarray(outdata[key])
-    outhdf['time'].attrs['epoch']=t0.isoformat()
+        outhdf[key] = dm.dmarray(outdata[key])
+    outhdf['time'].attrs['epoch'] = t0.isoformat()
     outhdf.toHDF5('advected.h5')

--- a/advect_imf.py
+++ b/advect_imf.py
@@ -292,7 +292,12 @@ def parse_args(starttime=None, endtime=None):
                 config.readfp(fh)  # legacy Python 2 support
         for ckey in config.options('Settings'):
             try:
-                args.__dict__[ckey] = config.get('Settings', ckey)
+                setting = config.get('Settings', ckey)
+                if ckey.endswith('time'):
+                    setting = datetime.strptime(setting, '%Y-%m-%dT%H:%M:%S')
+                elif ckey.lower() in ['ncells', 'output_x']:
+                    setting = int(setting)
+                args.__dict__[ckey] = setting
             except:
                 pass
 

--- a/advect_imf.py
+++ b/advect_imf.py
@@ -317,11 +317,11 @@ def parse_args(starttime=None, endtime=None):
     return args
 
 
-def fetch_solarwind(starttime, endtime, source='DSCOVR', proxy=None):
+def fetch_solarwind(starttime, endtime, source='DSCOVR', proxy=None, noise=True):
     if source == 'DSCOVR':
-        sw_data = load_dscovr(starttime, endtime, proxy=proxy)
+        sw_data = load_dscovr(starttime, endtime, proxy=proxy, noise=noise)
     elif source == 'ACE':
-        sw_data = load_acedata(starttime, endtime, proxy=proxy)
+        sw_data = load_acedata(starttime, endtime, proxy=proxy, noise=noise)
     else:
         raise ValueError('Invalid source ''{}'''.format(source))
 
@@ -342,7 +342,7 @@ if __name__ == '__main__':
     ncells = args.ncells
 
     # Fetch solar wind data
-    sw_data = fetch_solarwind(starttime, endtime, source, proxy)
+    sw_data = fetch_solarwind(starttime, endtime, source=source, proxy=proxy, noise=noise)
 
     # Initialize the simulation state
     state, outdata, t0, l1data_tnum = initialize(sw_data, ncells=ncells, output_x=output_x)

--- a/advect_imf.py
+++ b/advect_imf.py
@@ -48,7 +48,10 @@ def load_acedata(tstart, tend, noise=True, proxy=None):
         for dataset, local_name, cdaweb_name in [(mag_data, 'b', 'BGSM'),
                                                  (swepam_data, 'u', 'V_GSM'),
                                                  (swepam_data, '', 'SC_pos_GSM')]:
-            t, values = dataset['Epoch'], fill_gaps(dataset[cdaweb_name][:, i], noise=noise)
+            t = dataset['Epoch']
+            values = fill_gaps(dataset[cdaweb_name][:, i],
+                               fillval=dataset[cdaweb_name].attrs['FILLVAL'],
+                               noise=noise)
 
             # Grab the appropriate component from
             # VALIDMIN and VALIDMAX attributes
@@ -99,7 +102,10 @@ def load_dscovr(tstart, tend, noise=True, proxy=None):
                 (mag_data, 'b', 'B1GSE', 'Epoch1'),
                 (plasma_data, 'u', 'V_GSE', 'Epoch'),
                 (orbit_data, '', 'GSE_POS', 'Epoch')]:
-            t, values = dataset[cdaweb_time_var], fill_gaps(dataset[cdaweb_name][:, i], noise=noise)
+            t = dataset[cdaweb_time_var]
+            values = fill_gaps(dataset[cdaweb_name][:, i],
+                               fillval=dataset[cdaweb_name].attrs['FILLVAL'],
+                               noise=noise)
 
             for attr in ('VALIDMIN', 'VALIDMAX'):
 

--- a/advect_imf.py
+++ b/advect_imf.py
@@ -262,6 +262,11 @@ def parse_args(starttime=None, endtime=None):
                         dest='output_x',
                         help='Location used for output, given in km upstream ' +
                              'of Earth. Defaults to 203872 (32 Earth radii).')
+    parser.add_argument('--ncells',
+                        default=1000,
+                        dest=ncells,
+                        help='Number of cells, between L1 and Earth, used by advection ' +
+                             'code. Defaults to 1000.')
     parser.add_argument('--source', default='DSCOVR',
                         help='Solar wind data source ("ACE" or "DSCOVR")')
     parser.add_argument('--proxy', help='Proxy server URL')
@@ -326,14 +331,14 @@ if __name__ == '__main__':
     endtime = args.end_time
     source = args.source
     proxy = args.proxy
+    output_x = args.output_x
+    ncells = args.ncells
 
     # Fetch solar wind data
     sw_data = fetch_solarwind(starttime, endtime, source, proxy)
 
-    output_x = 203872
-
     # Initialize the simulation state
-    state, outdata, t0, l1data_tnum = initialize(sw_data, output_x=output_x)
+    state, outdata, t0, l1data_tnum = initialize(sw_data, ncells=ncells, output_x=output_x)
 
     # Stop time of simulation is last point for which all variables have valid data
     tmax = np.min([t[-1] for var, (t, values) in l1data_tnum.items()])

--- a/advect_imf.py
+++ b/advect_imf.py
@@ -253,6 +253,11 @@ def parse_args(starttime=None,endtime=None):
                         dest='end_time',
                         help='Start time of solar wind observations, ' + \
                              'universal time in YYYY-MM-DDTHH:MM:SS')
+    parser.add_argument('--output-x',
+                        default=203872,
+                        dest='output_x',
+                        help='Location used for output, given in km upstream ' + \
+                             'of Earth. Defaults to 203872 (32 Earth radii).')
     parser.add_argument('--source', default='DSCOVR',
                         help='Solar wind data source ("ACE" or "DSCOVR")')
     parser.add_argument('--proxy', help='Proxy server URL')
@@ -319,7 +324,7 @@ if __name__=='__main__':
     # Fetch solar wind data
     sw_data=fetch_solarwind(starttime,endtime,source,proxy)
 
-    output_x=0
+    output_x=203872
 
     # Initialize the simulation state
     state,outdata,t0,l1data_tnum=initialize(sw_data,output_x=output_x)

--- a/missing.py
+++ b/missing.py
@@ -60,11 +60,12 @@ def fill_gaps(data, fillval=9999999, sigma=5, winsor=0.05, noise=False, constrai
         # draw fluctuations from CDF and apply to linearly filled gaps
         for gap in gaps:
             for i in range(gap[1]-gap[0]+1):
-                data[gap[0]+i] += dx[p.searchsorted(random.random())]
+                series[gap[0]+i] += dx[p.searchsorted(random.random())]
 
         # cap variable if it should be strictly positive (e.g. number density)
         # use lowest measured value as floor
         if constrain and series.min() > 0.0:
-            data[data < series.min()] = series.min()
+            series[series < series.min()] = series.min()
+        return series
 
     return data

--- a/missing.py
+++ b/missing.py
@@ -1,8 +1,8 @@
-import copy
 import random
 import numpy as np
 import spacepy.toolbox as tb
 from scipy.ndimage.filters import gaussian_filter
+
 
 def fill_gaps(data, fillval=9999999, sigma=5, winsor=0.05, noise=False, constrain=False):
     '''Fill gaps in input data series, using interpolation plus noise
@@ -14,28 +14,28 @@ def fill_gaps(data, fillval=9999999, sigma=5, winsor=0.05, noise=False, constrai
     sigma - width of gaussian filter for finding fluctuation CDF
     winsor - winsorization threshold, values above p=1-winsor and below p=winsor are capped
     noise - Boolean, if True add noise to interpolated region, if False use linear interp only
-    constrain - Boolean, if True 
+    constrain - Boolean, if True
     '''
     # identify sequences of fill in data series
-    gaps = np.zeros((len(data),2),dtype=int)
+    gaps = np.zeros((len(data), 2), dtype=int)
     k = 0
-    for i in range(1,len(data)-1):
+    for i in range(1, len(data)-1):
         # Single space gap/fillval
-        if (tb.feq(data[i],fillval)) and (~tb.feq(data[i+1],fillval)) and (~tb.feq(data[i-1],fillval)):
+        if (tb.feq(data[i], fillval)) and (~tb.feq(data[i+1], fillval)) and (~tb.feq(data[i-1], fillval)):
             gaps[k][0] = i
             gaps[k][1] = i
             k += 1
         # Start of multispace gap/fillval
-        elif (tb.feq(data[i],fillval)) and (~tb.feq(data[i-1],fillval)):
+        elif (tb.feq(data[i], fillval)) and (~tb.feq(data[i-1], fillval)):
             gaps[k][0] = i
         # End of multispace gap/fillval
-        elif (tb.feq(data[i],fillval)) and (~tb.feq(data[i+1],fillval)):
+        elif (tb.feq(data[i], fillval)) and (~tb.feq(data[i+1], fillval)):
             gaps[k][1] = i
             k += 1
     gaps = gaps[:k]
 
-    #if no gaps detected
-    if k==0:
+    # if no gaps detected
+    if k == 0:
         return data
 
     # fill gaps with linear interpolation
@@ -52,7 +52,7 @@ def fill_gaps(data, fillval=9999999, sigma=5, winsor=0.05, noise=False, constrai
         smooth = gaussian_filter(series, sigma)
         dx = series-smooth
         dx.sort()
-        p = np.linspace(0,1,len(dx))
+        p = np.linspace(0, 1, len(dx))
         # "Winsorize" - all delta-Var above/below threshold at capped at threshold
         dx[:p.searchsorted(0.+winsor)] = dx[p.searchsorted(0.+winsor)+1]
         dx[p.searchsorted(1.-winsor):] = dx[p.searchsorted(1.-winsor)-1]

--- a/plot_imf.py
+++ b/plot_imf.py
@@ -1,72 +1,76 @@
-from spacepy import datamodel as dm
-from cdaweb import get_cdf
-from datetime import datetime,timedelta
-import dateutil.parser
-import numpy as np
-from advect_imf import parse_args,fetch_solarwind
+# stdlib
+from datetime import datetime
 
+# local
+from cdaweb import get_cdf
+from advect_imf import parse_args, fetch_solarwind
 from cache_decorator import cache_result
 
+# others
+import numpy as np
+from spacepy import datamodel as dm
 from matplotlib import pyplot as plt
 from matplotlib.gridspec import GridSpec
 
+
 @cache_result()
-def load_omni(dtstart,dtend, proxy=None):
-    return get_cdf('sp_phys','OMNI_HRO_1MIN',dtstart,dtend,['BX_GSE','BY_GSM','BZ_GSM','Vx','Vy','Vz','T','proton_density'], proxy=proxy)
+def load_omni(dtstart, dtend, proxy=None):
+    return get_cdf('sp_phys', 'OMNI_HRO_1MIN', dtstart, dtend,
+                   ['BX_GSE', 'BY_GSM', 'BZ_GSM', 'Vx', 'Vy', 'Vz', 'T', 'proton_density'],
+                   proxy=proxy)
+
 
 # Read advect1d output
-advect1d_data=dm.fromHDF5('advected.h5')
-advect1d_data['time']=advect1d_data['time'].astype('datetime64')
+advect1d_data = dm.fromHDF5('advected.h5')
+advect1d_data['time'] = advect1d_data['time'].astype('datetime64')
 
 # Retrieve start/end times of data and rount to nearest second
-starttime=advect1d_data['time'][0].astype('datetime64[s]').astype(datetime)
-endtime=advect1d_data['time'][-1].astype('datetime64[s]').astype(datetime)
+starttime = advect1d_data['time'][0].astype('datetime64[s]').astype(datetime)
+endtime = advect1d_data['time'][-1].astype('datetime64[s]').astype(datetime)
 
-args=parse_args(starttime=starttime,endtime=endtime)
+args = parse_args(starttime=starttime, endtime=endtime)
 
-starttime=args.start_time
-endtime=args.end_time
-source=args.source
-proxy=args.proxy
+starttime = args.start_time
+endtime = args.end_time
+source = args.source
+proxy = args.proxy
 
 # Fetch OMNI data
-omnidata=load_omni(starttime,endtime, proxy=proxy)
+omnidata = load_omni(starttime, endtime, proxy=proxy)
 
-l1data=fetch_solarwind(starttime,endtime,source,proxy)
+l1data = fetch_solarwind(starttime, endtime, source, proxy)
 
-varlist=[
-    ('$u_x$ (km/s)','ux','Vx'),
-    ('$u_y$ (km/s)','uy','Vy'),
-    ('$u_z$ (km/s)','uz','Vz'),
-    ('$b_x$ (nT)','bx','BX_GSE'),
-    ('$b_y$ (nT)','by','BY_GSM'),
-    ('$b_z$ (nT)','bz','BZ_GSM'),
-    (r'$\rho$ (cm$^{-3}$)','rho','proton_density'),
-    ('T (K)','T','T')
-]
+varlist = [('$u_x$ (km/s)', 'ux', 'Vx'),
+           ('$u_y$ (km/s)', 'uy', 'Vy'),
+           ('$u_z$ (km/s)', 'uz', 'Vz'),
+           ('$b_x$ (nT)', 'bx', 'BX_GSE'),
+           ('$b_y$ (nT)', 'by', 'BY_GSM'),
+           ('$b_z$ (nT)', 'bz', 'BZ_GSM'),
+           (r'$\rho$ (cm$^{-3}$)', 'rho', 'proton_density'),
+           ('T (K)', 'T', 'T')
+           ]
 
-gs=GridSpec(len(varlist),1)
+gs = GridSpec(len(varlist), 1)
+fig = plt.figure()
+axes = [fig.add_subplot(gs[0, 0])]
 
-fig=plt.figure()
+for i in range(1, len(varlist)):
+    axes.append(fig.add_subplot(gs[i, 0], sharex=axes[0]))
 
-axes=[fig.add_subplot(gs[0,0])]
-for i in range(1,len(varlist)):
-    axes.append(fig.add_subplot(gs[i,0],sharex=axes[0]))
-
-for i,(ylabel,advect1d_name,omni_name) in enumerate(varlist):
-    ax=axes[i]
+for i, (ylabel, advect1d_name, omni_name) in enumerate(varlist):
+    ax = axes[i]
 
     # Mask out bad OMNI data
-    omni_y=omnidata[omni_name]
-    mask=(omnidata[omni_name]<omnidata[omni_name].attrs['VALIDMIN'])|(omnidata[omni_name]>omnidata[omni_name].attrs['VALIDMAX'])
-    omni_y=np.ma.array(omni_y,mask=mask)
+    omni_y = omnidata[omni_name]
+    mask = (omnidata[omni_name] < omnidata[omni_name].attrs['VALIDMIN']) | (omnidata[omni_name] > omnidata[omni_name].attrs['VALIDMAX'])
+    omni_y = np.ma.array(omni_y, mask=mask)
 
     # Plot OMNI data and advect1d output for this variable
-    ax.plot(omnidata['Epoch'],omni_y,label='OMNI')
-    ax.plot(advect1d_data['time'],advect1d_data[advect1d_name],label='advect1d')
-    l1_t,l1_y=l1data[advect1d_name]
-    ax.plot(l1_t,l1_y,label='DSCOVR')
-    
+    ax.plot(omnidata['Epoch'], omni_y, label='OMNI')
+    ax.plot(advect1d_data['time'], advect1d_data[advect1d_name], label='advect1d')
+    l1_t, l1_y = l1data[advect1d_name]
+    ax.plot(l1_t, l1_y, label='DSCOVR')
+
     ax.set_ylabel(ylabel)
 
 axes[-1].legend(loc='best')

--- a/test_config
+++ b/test_config
@@ -2,3 +2,4 @@
 start_time = 2017-09-06T20:00:00
 end_time = 2017-09-07T05:00:00
 source = DSCOVR
+output_x = 203872

--- a/test_config
+++ b/test_config
@@ -1,0 +1,4 @@
+[Settings]
+start_time = 2017-09-06T20:00:00
+end_time = 2017-09-07T05:00:00
+source = DSCOVR


### PR DESCRIPTION
This PR:
- Adds the ability to use a configuration file (passed as an argument)
  - Includes a sample configuration file so the users know the form
  - Has some trapping so it still works with Python 2
- Updated the option parser
  - Explicitly stated the destination variables in the option parser
  - Adds the output location to the parsed options, changes the default to 32 Earth Radii (from 0)
  - Adds the number of cells to the parsed options (keeps default at 1000)
- Updates the code in `advect_imf.py`, `plot_imf.py`, and `missing.py` to comply (with a couple of minor exceptions) with PEP8, using the flake8 tool to lint the code
  - Includes cleaning up a couple of unused imports

It's easiest to see what was added by inspecting the first couple of commits individually, rather than the complete diffs (which are swamped by linting updates).